### PR TITLE
Fix misused header

### DIFF
--- a/Jellyfin.Plugin.Slack/Api/ServerApiEntryPoints.cs
+++ b/Jellyfin.Plugin.Slack/Api/ServerApiEntryPoints.cs
@@ -50,7 +50,6 @@ namespace Jellyfin.Plugin.Slack.Api
             {
                 Url = options.WebHookUrl,
                 RequestContent = _serializer.SerializeToString(parameters),
-                RequestHeaders = {[HeaderNames.ContentType] = "application/json"}
             };
 
             await _httpClient.Post(httpRequest).ConfigureAwait(false);

--- a/Jellyfin.Plugin.Slack/Jellyfin.Plugin.Slack.csproj
+++ b/Jellyfin.Plugin.Slack/Jellyfin.Plugin.Slack.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
-    <AssemblyVersion>2.0.0</AssemblyVersion>
-    <FileVersion>2.0.0</FileVersion>
+    <AssemblyVersion>3.0.0</AssemblyVersion>
+    <FileVersion>3.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.Slack/Notifier.cs
+++ b/Jellyfin.Plugin.Slack/Notifier.cs
@@ -54,8 +54,8 @@ namespace Jellyfin.Plugin.Slack
             {
                 Url = options.WebHookUrl,
                 RequestContent = _serializer.SerializeToString(parameters),
-                RequestHeaders = {[HeaderNames.ContentType] = "application/json"}
             };
+
             await _httpClient.Post(httpRequest).ConfigureAwait(false);
         }
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,8 @@
 ---
 name: "jellyfin-plugin-slack"
 guid: "94fb77c3-55ad-4c50-bf4e-4e5497467b79"
-version: "2" # Please increment with each pull request
-jellyfin_version: "10.3.0" # The earliest binary-compatible version
+version: "3" # Please increment with each pull request
+jellyfin_version: "10.3.7" # The earliest binary-compatible version
 nicename: "Slack Notifications"
 description: "Jellyfin Slack notification plugin"
 overview: >


### PR DESCRIPTION
I have been able to reproduce and fix this error. This was due to the ContentType being set on the Request object while it needed to be set on the Client itself (which i dont even know if this custom Client Wrapper supports). Found that settings this header isnt needed so i just stripped that out.

**Fixes**
#3