### PR TITLE
Compatibility with Slack-compatible webhooks

### DIFF
--- a/Jellyfin.Plugin.Slack/Api/ServerApiEntryPoints.cs
+++ b/Jellyfin.Plugin.Slack/Api/ServerApiEntryPoints.cs
@@ -45,6 +45,14 @@ namespace Jellyfin.Plugin.Slack.Api
             {
                 {"text", "This is a test notification from Jellyfin"}
             };
+            if (!string.IsNullOrEmpty(options.Username))
+            {
+                parameters.Add("username", options.Username);
+            }
+            if (!string.IsNullOrEmpty(options.IconUrl))
+            {
+                parameters.Add("icon_url", options.IconUrl);
+            }
 
             var httpRequest = new HttpRequestOptions
             {

--- a/Jellyfin.Plugin.Slack/Api/ServerApiEntryPoints.cs
+++ b/Jellyfin.Plugin.Slack/Api/ServerApiEntryPoints.cs
@@ -50,6 +50,7 @@ namespace Jellyfin.Plugin.Slack.Api
             {
                 Url = options.WebHookUrl,
                 RequestContent = _serializer.SerializeToString(parameters),
+                RequestContentType = "application/json",
             };
 
             await _httpClient.Post(httpRequest).ConfigureAwait(false);

--- a/Jellyfin.Plugin.Slack/Configuration/SlackConfiguration.cs
+++ b/Jellyfin.Plugin.Slack/Configuration/SlackConfiguration.cs
@@ -5,5 +5,7 @@
         public string WebHookUrl { get; set; }
         public bool IsEnabled { get; set; }
         public string JellyfinUserId { get; set; }
+        public string Username { get; set; }
+        public string IconUrl { get; set; }
     }
 }

--- a/Jellyfin.Plugin.Slack/Configuration/config.html
+++ b/Jellyfin.Plugin.Slack/Configuration/config.html
@@ -23,6 +23,18 @@
                             Webhook-URL for Jellyfin
                         </div>
                     </div>
+                    <div class="inputContainer">
+                        <input is="emby-input" type="text" id="txtSlackWebhookUsername" label="Webhook display name:"/>
+                        <div class="fieldDescription">
+                            Optional display name to use for notifications
+                        </div>
+                    </div>
+                    <div class="inputContainer">
+                        <input is="emby-input" type="text" id="txtSlackWebhookIconUrl" label="Webhook icon URL:"/>
+                        <div class="fieldDescription">
+                            Optional icon URL to use for notifications
+                        </div>
+                    </div>
                     <div>
                         <button is="emby-button" type="button" class="raised button-cancel block" id="testNotification">
                             <span>Test Notification</span>
@@ -48,6 +60,8 @@
 
                         $('#chkEnableSlack', page).checked(slackConfig.IsEnabled || false).checkboxradio("refresh");
                         $('#txtSlackWebhookUrl', page).val(slackConfig.WebHookUrl || '');
+                        $('#txtSlackWebhookUsername', page).val(slackConfig.Username || '');
+                        $('#txtSlackWebhookIconUrl', page).val(slackConfig.IconUrl || '');
                     });
                     Dashboard.hideLoadingMsg();
                 }
@@ -112,6 +126,8 @@
                         slackConfig.JellyfinUserId = userId;
                         slackConfig.IsEnabled = $('#chkEnableSlack', form).checked();
                         slackConfig.WebHookUrl = $('#txtSlackWebhookUrl', form).val();
+                        slackConfig.Username = $('#txtSlackWebhookUsername', form).val();
+                        slackConfig.IconUrl = $('#txtSlackWebhookIconUrl', form).val();
                         ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                     });
                     return false;

--- a/Jellyfin.Plugin.Slack/Notifier.cs
+++ b/Jellyfin.Plugin.Slack/Notifier.cs
@@ -54,6 +54,7 @@ namespace Jellyfin.Plugin.Slack
             {
                 Url = options.WebHookUrl,
                 RequestContent = _serializer.SerializeToString(parameters),
+                RequestContentType = "application/json",
             };
 
             await _httpClient.Post(httpRequest).ConfigureAwait(false);

--- a/Jellyfin.Plugin.Slack/Notifier.cs
+++ b/Jellyfin.Plugin.Slack/Notifier.cs
@@ -48,6 +48,14 @@ namespace Jellyfin.Plugin.Slack
                 {
                     {"text", $"{request.Name} \n {request.Description}"},
                 };
+            if (!string.IsNullOrEmpty(options.Username))
+            {
+                parameters.Add("username", options.Username);
+            }
+            if (!string.IsNullOrEmpty(options.IconUrl))
+            {
+                parameters.Add("icon_url", options.IconUrl);
+            }
 
             _logger.LogDebug("Notification to Slack : {0} - {1}", options.WebHookUrl, request.Description);
             var httpRequest = new HttpRequestOptions


### PR DESCRIPTION
As a lot of other serves support Slack-compatible webhooks, this PR makes Jellyfin's notifications work with more servers.

First of all, I've added the missing `Content-Type: application/json` header to make this work with Mattermost (#1) and other software. I've also tested this with Discord and Matrix, both can receive notifications with this header added.
Secondly I've added options to configure optional username and icon to use for notifications as both Discord and Matrix (and probably other software as well) support arbitrary usernames for webhooks.